### PR TITLE
macos compatible

### DIFF
--- a/qcowtools/mount_fuse.h
+++ b/qcowtools/mount_fuse.h
@@ -59,7 +59,11 @@ extern "C" {
 #if defined( HAVE_LIBFUSE ) || defined( HAVE_LIBFUSE3 ) || defined( HAVE_LIBOSXFUSE )
 
 int mount_fuse_set_stat_info(
+#ifdef __APPLE__
+     struct fuse_darwin_attr *stat_info,
+#else
      struct stat *stat_info,
+#endif
      size64_t size,
      uint16_t file_mode,
      int64_t access_time,
@@ -69,9 +73,15 @@ int mount_fuse_set_stat_info(
 
 int mount_fuse_filldir(
      void *buffer,
+#ifdef __APPLE__
+     fuse_darwin_fill_dir_t filler,
+     const char *name,
+     struct fuse_darwin_attr *stat_info,
+#else
      fuse_fill_dir_t filler,
      const char *name,
      struct stat *stat_info,
+#endif
      mount_file_entry_t *file_entry,
      libcerror_error_t **error );
 
@@ -98,7 +108,11 @@ int mount_fuse_opendir(
 int mount_fuse_readdir(
      const char *path,
      void *buffer,
+#ifdef __APPLE__
+     fuse_darwin_fill_dir_t filler,
+#else
      fuse_fill_dir_t filler,
+#endif
      off_t offset,
      struct fuse_file_info *file_info,
      enum fuse_readdir_flags flags );
@@ -106,7 +120,11 @@ int mount_fuse_readdir(
 int mount_fuse_readdir(
      const char *path,
      void *buffer,
+#ifdef __APPLE__
+     fuse_darwin_fill_dir_t filler,
+#else
      fuse_fill_dir_t filler,
+#endif
      off_t offset,
      struct fuse_file_info *file_info );
 #endif
@@ -118,12 +136,21 @@ int mount_fuse_releasedir(
 #if defined( HAVE_LIBFUSE3 )
 int mount_fuse_getattr(
      const char *path,
+#ifdef __APPLE__
+     struct fuse_darwin_attr *stat_info,
+#else
      struct stat *stat_info,
+#endif
      struct fuse_file_info *file_info );
 #else
 int mount_fuse_getattr(
      const char *path,
+#ifdef __APPLE__
+     struct fuse_darwin_attr *stat_info,
+     struct fuse_file_info *file_info );
+#else
      struct stat *stat_info );
+#endif
 #endif
 
 void mount_fuse_destroy(


### PR DESCRIPTION
make this project work on macos 15.6.1.

```shell
$ ./autogen.sh                                                                                                                                                                                                
 ⋮
$ CFLAGS="-I /opt/homebrew/include" LDFLAGS="-L/opt/homebrew/lib" ./configure --prefix /usr/local --enable-wide-character-type --enable-verbose-output
 ⋮
$ make                                                                                                                                                                                                         ⋮
$ make install
⋮
$ qcowinfo /Users/.../test.qcow2
qcowinfo 20240822

QEMU Copy-On-Write (QCOW) image information:
	Format version		: 3
	Media size		: 64 MiB (67108864 bytes)
	Encryption method	: None
	Number of snapshots	: 0

$ qcowmount /Users/.../data.qcow2 ~/mnt/qcow
qcowmount 20240822

$ hexdump -C ~/mnt/qcow/qcow1 | head -10
00000000  33 c0 8e d0 bc 00 7c 8e  c0 8e d8 be 00 7c bf 00  |3.....|......|..|
00000010  06 b9 00 02 fc f3 a4 50  68 1c 06 cb fb b9 04 00  |.......Ph.......|
00000020  bd be 07 80 7e 00 00 7c  0b 0f 85 0e 01 83 c5 10  |....~..|........|
00000030  e2 f1 cd 18 88 56 00 55  c6 46 11 05 c6 46 10 00  |.....V.U.F...F..|
00000040  b4 41 bb aa 55 cd 13 5d  72 0f 81 fb 55 aa 75 09  |.A..U..]r...U.u.|
00000050  f7 c1 01 00 74 03 fe 46  10 66 60 80 7e 10 00 74  |....t..F.f`.~..t|
00000060  26 66 68 00 00 00 00 66  ff 76 08 68 00 00 68 00  |&fh....f.v.h..h.|
00000070  7c 68 01 00 68 10 00 b4  42 8a 56 00 8b f4 cd 13  ||h..h...B.V.....|
00000080  9f 83 c4 10 9e eb 14 b8  01 02 bb 00 7c 8a 56 00  |............|.V.|
00000090  8a 76 01 8a 4e 02 8a 6e  03 cd 13 66 61 73 1c fe  |.v..N..n...fas..|
```

